### PR TITLE
Numeric cols

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 node_modules
+*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 .DS_Store
 node_modules
 *.swp
-crude-tests.js

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules
 *.swp
+crude-tests.js

--- a/lib/datakit.js
+++ b/lib/datakit.js
@@ -119,6 +119,33 @@ var col = module.exports.col = function(arr,key){
   return res;
 }
 
+// Assumes headings is an array of headings. Would be nice if it could also be an
+// array of column numbers. 
+var numeric = module.exports.numeric = function(data, headings, replaceBlanks) {
+  var heads = Array.prototype.slice.call(arguments, 1, 2)[0];
+  if (heads.length === 0 || heads === undefined) {
+    throw new Error('No headings supplied to numeric.');
+  }
+
+  var includeNaN = false;
+  
+  for (var i = 0; i < heads.length; i++) {
+    var head = heads[i];
+    for (var j = 0; j < data.length; j++) {
+      if (data[j][head] === '') {
+        data[j][head] = replaceBlanks || 0;
+      } else {
+        data[j][head] = Number(data[j][head]);
+      }
+    if (isNaN(data[j][head])) includeNaN = true;
+    };
+  };
+  
+  if (includeNaN === true) console.log("Warning: Some values are NaN.");
+
+  return data;
+};
+
 //RANDOM NUMBERS
 
 //array of exponential random variables

--- a/spec/test/test2.csv
+++ b/spec/test/test2.csv
@@ -1,0 +1,4 @@
+COL1,COL2,COL3
+Group1,1,1
+Group2,2,2
+Group3,,3

--- a/spec/test/test2.csv
+++ b/spec/test/test2.csv
@@ -1,4 +1,4 @@
 COL1,COL2,COL3
-Group1,1,1
-Group2,2,2
+Group1,1,2
+Group2,2,3
 Group3,,3

--- a/spec/test/testSpec.js
+++ b/spec/test/testSpec.js
@@ -174,3 +174,27 @@ describe('plot',function(){
     done();
   });
 });
+
+describe('numeric', function() {
+  var d;
+  beforeEach(function(done) {
+    dk.csv('spec/test/test2.csv', function(data) {
+      d = dk.numeric(data, ['COL2'], 6253);
+      //d = data;
+      done();
+    });
+  });
+
+  it('should convert string values to numbers', function(done) {
+    expect(dk.col(d, 'COL2')[0]).toBe(1);
+    done();
+  });
+
+
+  it('should convert empty cells to the supplied default', function(done) {
+    expect(dk.col(d, 'COL2')[2]).toBe(6253);
+    done();
+  });
+
+
+});

--- a/spec/test/testSpec.js
+++ b/spec/test/testSpec.js
@@ -179,17 +179,16 @@ describe('numeric', function() {
   var d;
   beforeEach(function(done) {
     dk.csv('spec/test/test2.csv', function(data) {
-      d = dk.numeric(data, ['COL2'], 6253);
-      //d = data;
+      d = dk.numeric(data, ['COL2', 'COL3'], 6253);
       done();
     });
   });
 
   it('should convert string values to numbers', function(done) {
     expect(dk.col(d, 'COL2')[0]).toBe(1);
+    expect(dk.col(d, 'COL3')[0]).toBe(2);
     done();
   });
-
 
   it('should convert empty cells to the supplied default', function(done) {
     expect(dk.col(d, 'COL2')[2]).toBe(6253);


### PR DESCRIPTION
Hi Nathan,

Don't know if you're open to pull requests, but I've been looking around at options for data analysis in javascript, which led me to looking through Datakit.  Since the way `csv` in datakit reads csv files turns all values into strings, I thought it would be useful to have a method that turns select column values into numbers, so that functions like `mean` can be immediately called on them. The function I added is `numeric` and takes three parameters, first is the parsed csv object, second is an array of column heading names (the ones to convert to numbers), and last is a default value, which is what all empty cells in the given columns will be set to (defaults to 0). I've also added tests to `testSpec.js` and another sameple csv file (`test2.csv`) for testing the new method. 

In any case, you've made a really useful library. Thanks for making it.  

-Aaron 